### PR TITLE
Feat(Bulk-Import): Added back button from bulk import page)

### DIFF
--- a/src/modules/Dashboard/modules/Tasks/TaskBulkImport.tsx
+++ b/src/modules/Dashboard/modules/Tasks/TaskBulkImport.tsx
@@ -3,8 +3,9 @@ import { convertToXLSX } from "./TaskApis";
 import { SingleButton } from "@/MuLearnComponents/MuButtons/MuButton";
 import { dashboardRoutes } from "@/MuLearnServices/urls";
 import { useState, useMemo, MouseEventHandler } from "react";
-import { BiDownload } from "react-icons/bi";
+import { BiDownload, BiArrowBack } from "react-icons/bi";
 import { useToast } from "@chakra-ui/react";
+import { useNavigate } from "react-router-dom";
 
 type Props = {};
 
@@ -19,6 +20,7 @@ const CountCard = ({ title, count }: { title: string; count: number }) => {
 
 const TaskBulkImport = (props: Props) => {
     const [uploadResponse, setUploadResponse] = useState<any>(null);
+    const navigate = useNavigate();
     const handleClick = () => {
         //console.log("worked")
     };
@@ -39,12 +41,34 @@ const TaskBulkImport = (props: Props) => {
 
     return (
         <>
-            <SingleButton
-                text={"Download Template"}
-                onClick={handleClick}
-                icon={<BiDownload />}
-                link="https://drive.google.com/uc?export=download&id=1b2DUyj6zxDzY8q5pDTbL3NlZEL1J1dcq"
-            />
+            <div
+                style={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    width: "100%",
+                    alignItems: "center"
+                }}
+            >
+                <SingleButton
+                    text={"Go Back"}
+                    icon={<BiArrowBack />}
+                    style={{
+                        display: "flex",
+                        justifyContent: "start",
+                        width: "100%",
+                        alignItems: "center"
+                    }}
+                    onClick={() => {
+                        navigate("/dashboard/tasks");
+                    }}
+                />
+                <SingleButton
+                    text={"Download Template"}
+                    onClick={handleClick}
+                    icon={<BiDownload />}
+                    link="https://drive.google.com/uc?export=download&id=1b2DUyj6zxDzY8q5pDTbL3NlZEL1J1dcq"
+                />
+            </div>
 
             <BulkImport
                 path={dashboardRoutes.getTasksData + "import/"}


### PR DESCRIPTION
# Description

Adds a back button to TaskBulkImport.tsx for going back to the tasks page from bulk import page easily.

## Type of change

Please delete options that are not relevant.

- [x] New Feature (non-breaking change which adds functionality)


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

