### PR TITLE
fix:  layout styles in OpenGrad

### DIFF
--- a/src/modules/Dashboard/modules/OpenGrad/index.module.css
+++ b/src/modules/Dashboard/modules/OpenGrad/index.module.css
@@ -1,7 +1,9 @@
 /* General Styles */
-.wrapper{
+.wrapper {
     border-top: 0.3px solid gray;
-
+    display: flex;
+    flex-direction: column;
+    align-items: center;
 }
 
 .wrapper h1 {
@@ -113,6 +115,10 @@
     .containercard {
         width: 85vw;
         height: auto; /* Adjust height to maintain aspect ratio */
+        margin: 10px;
+    }
+    .second_view_container {
+        padding: 0 !important;
     }
 }
 


### PR DESCRIPTION
## Fixes Issue

Closes #1816 

## Changes proposed

Add flex property in wrapper container and remove the padding in sm, md, and large viewport 
## Before

[Screencast from 2025-04-06 21-45-58.webm](https://github.com/user-attachments/assets/1f9b778b-31ea-41ce-8f22-e11160da628f)

## After

[Screencast from 2025-04-06 21-44-41.webm](https://github.com/user-attachments/assets/760e4d3e-4fa5-4791-99ee-608fd7d4fbf1)

## Additional Context
In production, the WF course container has 2 columns but in dev, there are 3 columns
