### PR TITLE
fix(profile): prevent negative percentile values

### DIFF
--- a/src/modules/Dashboard/modules/Profile/pages/Profile.tsx
+++ b/src/modules/Dashboard/modules/Profile/pages/Profile.tsx
@@ -781,9 +781,9 @@ const Profile = () => {
                                                     <div>
                                                         <span>Percentile</span>
                                                         <h1>
-                                                            {parseFloat(
+                                                            {Math.max(0, parseFloat(
                                                                 userProfile.percentile
-                                                            ).toFixed(2)}
+                                                            )).toFixed(2)}
                                                         </h1>
                                                     </div>
                                                 </div>


### PR DESCRIPTION
## Problem
The profile page was displaying negative percentile values, which is mathematically impossible since percentiles should always be between 0 and 100.

## Solution
Added `Math.max(0, ...)` wrapper around the percentile display to ensure negative values are clamped to 0.

## Changes
- Modified `src/modules/Dashboard/modules/Profile/pages/Profile.tsx`
- Changed percentile display from `parseFloat(userProfile.percentile).toFixed(2)` to `Math.max(0, parseFloat(userProfile.percentile)).toFixed(2)`

## Testing
- Verified the fix with lint (no new errors introduced)
- The change is minimal and focused on the specific issue

Fixes #2022