### PR TITLE
fix: include top 3 ranks in leaderboard table

### DIFF
--- a/src/modules/Dashboard/modules/LeaderBoard/components/Leaderboard.tsx
+++ b/src/modules/Dashboard/modules/LeaderBoard/components/Leaderboard.tsx
@@ -65,7 +65,7 @@ export default function Leaderboard({
   }
 
   const topPlayers = currentLeaderboard.slice(0, topPlayerCount);
-  const remainingPlayers = currentLeaderboard.slice(topPlayerCount);
+  const remainingPlayers = currentLeaderboard; // ← fixed: was currentLeaderboard.slice(topPlayerCount)
 
   return (
     <div className={styles.container}>


### PR DESCRIPTION
## Problem
The leaderboard table was skipping ranks 1, 2, and 3. 
Users who wanted to see the full leaderboard in list format 
could not do so because the top 3 were only shown in the 
visual podium and completely absent from the table below.

## Root Cause
In `Leaderboard.tsx`, the table was receiving 
`currentLeaderboard.slice(topPlayerCount)` which cut off 
the first 3 entries before passing data to `LeaderboardTable`.

## Fix
Changed `remainingPlayers` to use the full `currentLeaderboard` 
array so all ranks including 1, 2, and 3 appear in the table.

## Changes
- File: `src/modules/Dashboard/modules/LeaderBoard/components/Leaderboard.tsx`
- Line 68: `currentLeaderboard.slice(topPlayerCount)` → `currentLeaderboard`

## Steps to Reproduce
1. Go to https://app.mulearn.org/dashboard/leaderboard
2. Observe podium shows ranks 1, 2, 3
3. Observe table starts from rank 4

## Expected Behavior
Table should show all ranks starting from 1 so the 
full leaderboard is visible in list format.